### PR TITLE
Adding Routing and State Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Bivrost is a asp.net core application that offers several overlay endpoints, hos
 
 ## Getting Started
 
+Put your left foot in.
+
 ### Running on Zeit Now
 
 If you want to start using Bivrost as is with no customizations, this can easily be done with Zeit's Now platform.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,7 +1,32 @@
 # Notes
 
+## Inspiration
+
+- [Mike Jolly's IO](https://github.com/MichaelJolley/io)
+- [Vuex Sample App](https://github.com/vuejs/vuex)
+- [Securing Vue](https://github.com/NotMyself/securing-vue)
+
+## Library Documentation
+
+### Client Side
+
+- [Vue.js](https://vuejs.org/v2/guide/)
+- [Vue Router](https://router.vuejs.org/)
+- [Vuex](https://vuex.vuejs.org/)
+- [@aspnet/signalr](https://github.com/aspnet/AspNetCore/tree/master/src/SignalR)
+- [aspnet-webpack](https://github.com/aspnet/AspNetCore/tree/master/src/Middleware/SpaServices/src/npm/aspnet-webpack)
+
+### Server Side
+
+- [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-2.2)
+- [Web API](https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-2.2)
+- [SignalR](https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-2.2)
+- [JavaScript Services](https://docs.microsoft.com/en-us/aspnet/core/client-side/spa-services?view=aspnetcore-2.2)
+- [Serilog](https://github.com/serilog/serilog/wiki/Getting-Started)
+- [TwitchLib](https://github.com/TwitchLib/TwitchLib)
+
 ## Useful Links
 
 - [Twitch Token Generator](https://twitchtokengenerator.com) - Create OAuth Twitch tokens with specific scopes.
 - [Twitch Useful Scripts](https://bashtech.net/twitch/index.html) - Can get channel id here.
--
+

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -10897,6 +10897,11 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-router": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.6.tgz",
+      "integrity": "sha512-Ox0ciFLswtSGRTHYhGvx2L44sVbTPNS+uD2kRISuo8B39Y79rOo0Kw0hzupTmiVtftQYCZl87mwldhh2L9Aquw=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
@@ -10922,6 +10927,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vuex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.0.tgz",
+      "integrity": "sha512-mdHeHT/7u4BncpUZMlxNaIdcN/HIt1GsGG5LKByArvYG/v6DvHcOxvDCts+7SRdCoIRGllK8IMZvQtQXLppDYg=="
     },
     "watchpack": {
       "version": "1.6.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "@aspnet/signalr": "^1.1.4",
     "core-js": "^2.6.5",
-    "vue": "^2.6.10"
+    "vue": "^2.6.10",
+    "vue-router": "^3.0.6",
+    "vuex": "^3.1.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.7.0",

--- a/src/client/src/App.vue
+++ b/src/client/src/App.vue
@@ -1,22 +1,17 @@
 <template>
   <div id="app">
-    <img alt="Vue logo" src="./assets/logo.png">
-    <HelloWorld msg="Welcome to Your Vue.js App"/>
+    <router-view />
   </div>
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
-
 export default {
   name: 'app',
   components: {
-    HelloWorld
   },
   sockets: {
     receiveChatMessage(message) {
-      // eslint-disable-next-line no-console
-      console.log(message);
+      this.$store.dispatch('chat/addMessage', message);
     },
   }
 }

--- a/src/client/src/main.js
+++ b/src/client/src/main.js
@@ -1,16 +1,23 @@
 import Vue from 'vue'
 import VueSignalR from './services/signalr'
+
+import router from './router';
+import store from './store';
+
 import App from './App.vue'
+
 
 Vue.config.productionTip = false
 
 Vue.use(VueSignalR, '/client-hub');
 
 new Vue({
+  router,
+  store,
   render: h => h(App),
   created() {
     this.$socket.start({
-      log: true // Active only in development for debugging.
+      log: false
     });
   },
-}).$mount('#app')
+}).$mount('#app');

--- a/src/client/src/pages/ChatOverlayPage.vue
+++ b/src/client/src/pages/ChatOverlayPage.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <h3 class="text-center">ChatOverlayPage</h3>
+    <hr/>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'chatOverlayPage',
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/src/client/src/pages/HomePage.vue
+++ b/src/client/src/pages/HomePage.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <h3 class="text-center">HomePage</h3>
+    <hr/>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'homePage',
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/src/client/src/router/index.js
+++ b/src/client/src/router/index.js
@@ -1,0 +1,23 @@
+import Vue from 'vue';
+import Router from 'vue-router';
+
+import ChatOverlayPage from '@/pages/ChatOverlayPage.vue';
+import HomePage from '@/pages/HomePage.vue';
+
+Vue.use(Router);
+
+export default new Router({
+  mode: 'history',
+  routes: [
+    {
+      path: '/',
+      name: 'HomePage',
+      component: HomePage,
+    },
+    {
+      path: '/overlays/chat',
+      name: 'ChatOverlayPage',
+      component: ChatOverlayPage,
+    },
+  ],
+});

--- a/src/client/src/store/index.js
+++ b/src/client/src/store/index.js
@@ -1,0 +1,12 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+import chat from './modules/chat'
+
+Vue.use(Vuex);
+
+export default new Vuex.Store({
+  modules: {
+    chat
+  }
+});

--- a/src/client/src/store/modules/chat.js
+++ b/src/client/src/store/modules/chat.js
@@ -1,0 +1,31 @@
+
+
+const state = {
+  chatMessages: [],
+}
+
+const getters = {
+  getMessages(state) {
+    return state.chatMessages;
+  }
+}
+
+const actions = {
+  addMessage({ commit }, message) {
+    commit('addMessage', message);
+  }
+}
+
+const mutations = {
+  addMessage(state, message) {
+    state.items.push(message);
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/src/client/src/store/modules/chat.js
+++ b/src/client/src/store/modules/chat.js
@@ -18,7 +18,7 @@ const actions = {
 
 const mutations = {
   addMessage(state, message) {
-    state.items.push(message);
+    state.chatMessages.push(message);
   }
 }
 

--- a/src/server/Controllers/FallbackController.cs
+++ b/src/server/Controllers/FallbackController.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Bivrost.Web.Controllers
+{
+  public class FallbackController : Controller
+  {
+    public IActionResult Index()
+    {
+      return File("~/index.html", "text/html");
+    }
+
+    public IActionResult Test()
+    {
+      return Content("Passed");
+    }
+  }
+}

--- a/src/server/Startup.cs
+++ b/src/server/Startup.cs
@@ -37,9 +37,9 @@ namespace Bivrost.Web
 
       services.AddMvc();
       services.AddSignalR(config =>
-            {
-                config.EnableDetailedErrors = true;
-            });
+      {
+          config.EnableDetailedErrors = true;
+      });
       // In production, the Vue files will be served
       //  from this directory
       services.AddSpaStaticFiles(configuration =>

--- a/src/server/Startup.cs
+++ b/src/server/Startup.cs
@@ -88,11 +88,11 @@ namespace Bivrost.Web
               spa.Options.DefaultPage = "/index.html";
             });
 
-            // app.UseMvc(routes => {
-            //   routes.MapSpaFallbackRoute(
-            //       name: "spa-fallback",
-            //       defaults: new { controller = "Fallback", action = "Index" });
-            // });
+            app.UseMvc(routes => {
+              routes.MapSpaFallbackRoute(
+                  name: "spa-fallback",
+                  defaults: new { controller = "Fallback", action = "Index" });
+            });
           });
 
       }

--- a/src/server/Startup.cs
+++ b/src/server/Startup.cs
@@ -38,7 +38,8 @@ namespace Bivrost.Web
       services.AddMvc();
       services.AddSignalR(config =>
       {
-          config.EnableDetailedErrors = true;
+          config.EnableDetailedErrors =
+            Configuration.GetValue("Signalr_Errors", false);
       });
       // In production, the Vue files will be served
       //  from this directory
@@ -50,38 +51,51 @@ namespace Bivrost.Web
 
     public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     {
-      if (env.IsDevelopment())
+      //set up serverside development handler
+      if(env.IsDevelopment())
       {
         app.UseDeveloperExceptionPage();
+      }
+
+      //set up signalr routing
+      app.UseSignalR(routes =>
+      {
+          routes.MapHub<ClientHub>("/client-hub");
+      });
+
+      //set up default mvc routing
+      app.UseMvc(routes =>
+      {
+        routes.MapRoute("default", "api/{controller=Home}/{action=Index}/{id?}");
+      });
+
+      //setup spa routing for both dev and prod
+      if (env.IsDevelopment())
+      {
         app.UseWebpackDevMiddleware(new WebpackDevMiddlewareOptions {
             HotModuleReplacement = true,
             ProjectPath = Path.Combine(env.ContentRootPath, Configuration["ClientProjectPath"]),
             ConfigFile = Path.Combine(env.ContentRootPath, Configuration["ClientProjectConfigPath"])
         });
       }
-
-      if(env.IsProduction()) {
-        app.UseSpaStaticFiles();
-        app.UseSpa(spa => {
-          spa.Options.DefaultPage = "/index.html";
-        });
-      }
-
-      app.UseSignalR(routes =>
-            {
-                routes.MapHub<ClientHub>("/client-hub");
+      else
+      {
+        app.UseWhen(context => !context.Request.Path.Value.StartsWith("/api")
+          && !context.Request.Path.Value.StartsWith("/client-hub"),
+          builder => {
+            app.UseSpaStaticFiles();
+            app.UseSpa(spa => {
+              spa.Options.DefaultPage = "/index.html";
             });
 
-      app.UseMvc(routes =>
-      {
-          routes.MapRoute(
-              name: "default",
-              template: "{controller=Home}/{action=Index}/{id?}");
+            // app.UseMvc(routes => {
+            //   routes.MapSpaFallbackRoute(
+            //       name: "spa-fallback",
+            //       defaults: new { controller = "Fallback", action = "Index" });
+            // });
+          });
 
-          routes.MapSpaFallbackRoute(
-              name: "spa-fallback",
-              defaults: new { controller = "Home", action = "Index" });
-      });
+      }
     }
   }
 }

--- a/src/server/appsettings.Development.json
+++ b/src/server/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "Client":"../client/dist",
   "ClientProjectPath": "../client",
   "ClientProjectConfigPath":"../client/node_modules/@vue/cli-service/webpack.config.js",
   "Logging": {

--- a/src/server/appsettings.json
+++ b/src/server/appsettings.json
@@ -2,7 +2,7 @@
   "BIVROST_TWITCH_BOT_USER_NAME":"did-not-find-a-valid-env-var-or-user-secret-for-this",
   "BIVROST_TWITCH_BOT_ACCESS_TOKEN":"did-not-find-a-valid-env-var-or-user-secret-for-this",
   "BIVROST_TWITCH_BOT_CHANNEL":"did-not-find-a-valid-env-var-or-user-secret-for-this",
-  "Client": "../client",
+  "Signalr_Errors": "false",
   "Logging": {
     "LogLevel": {
       "Default": "Warning"


### PR DESCRIPTION
Adding in [Vue Routing](https://router.vuejs.org/) and [Vuex](https://vuex.vuejs.org/).

- [x] Add Vuex
- [x] Add Vue Routing
- [ ] Ensure client side routing works
- [x] Ensure a chat message is dispatched from server => signalr => Vuex

Filed a bug in the AspNetCore repo for the client side routing issue. aspnet/AspNetCore#10002

Also reached out to @jkotalik as a last-ditch attempt at sanity.

Given there are several things going on in this project WRT routing, this is how it should work:

**Development Configuration**
- [x] **api route:** `http://localhost/api/*` should be handled by MVC middleware
- [x] **websocket route:** `http://localhost/client-hub` should be handled by Signalr middleware
- [x] **default route:** `http://localhost/` should return spa application via Webpack dev middleware
- [ ] **all others:** `http://localhost/**/*` should return the spa application via webpack dev middleware

**Production Configuration**
- [x] **api route:** `http://localhost/api/*` should be handled by MVC middleware
- [x] **websocket route:** `http://localhost/client-hub` should be handled by Signalr middleware
- [x] **default route:** `http://localhost/` should return spa application via spa static files middleware
- [x] **all others:** `http://localhost/**/*` should return the spa application via spa static files middleware